### PR TITLE
Update fail body to be string to handle symon error

### DIFF
--- a/src/handlers/status-simulator.ts
+++ b/src/handlers/status-simulator.ts
@@ -36,5 +36,5 @@ export async function getStatusSimulator(
 
   fail++;
   request.log.info('Status code simulator returning status 500');
-  return reply.status(500).send({ success: false, message: 'Fail', data: {} });
+  return reply.status(500).send('fail');
 }


### PR DESCRIPTION
This is a quick fix to handle error when sending incident email in symon. Change the body to string will fix it
![Screenshot 2024-01-19 at 14 07 12](https://github.com/hyperjumptech/monika-alert-simulator/assets/5974862/a22e6b8c-6507-4cb9-b65a-b7c9412c7e06)

*need further digging in symon part also